### PR TITLE
Fix activity crash in FontButton

### DIFF
--- a/fontcombobox.py
+++ b/fontcombobox.py
@@ -40,8 +40,6 @@ class FontButton(ToolButton):
     }
 
     def __init__(self):
-        Gtk.ComboBox.__init__(self)
-
         ToolButton.__init__(self, icon_name='font-text',
                             tooltip=_('Select font'))
         self.connect('clicked', self.__font_selection_cb)


### PR DESCRIPTION
Remove alien call to Gtk.ComboBox.**init**, this caused
the activity to break in F21 + Sugar 0.102.

Signed-off-by: Martin Abente Lahaye tch@sugarlabs.org
