### PR TITLE
Fix GtkBox warnings

### DIFF
--- a/activity.py
+++ b/activity.py
@@ -182,8 +182,6 @@ class MemorizeActivity(Activity):
         height = Gdk.Screen.height() - style.GRID_CELL_SIZE
         self.table.resize(width, height - style.GRID_CELL_SIZE)
         self.scoreboard.set_size_request(-1, style.GRID_CELL_SIZE)
-        self.box.pack_start(self.table, True, True, 0)
-        self.box.pack_start(self.scoreboard, False, False, 0)
         self.set_canvas(self.box)
 
         # connect to the in/out events of the memorize activity


### PR DESCRIPTION
FIxes #11 
Easy fix, a couple of lines were redundant in activity.py

@quozl wrote:

> Need a way to isolate these warnings to specific Python source lines.

were you talking about developing a way such that these type of problems can be solved in any general activity or was it this activity specific?

Though on change the number(size) of the cards, a few errors are still logged
```
(sugar-activity:8183): Gtk-WARNING **: Drawing a gadget with negative dimensions. Did you forget to allocate a size? (node menuitem owner SugarPaletteHeader)

(sugar-activity:8183): Gtk-WARNING **: Drawing a gadget with negative dimensions. Did you forget to allocate a size? (node menuitem owner SugarPaletteHeader)
````