### PR TITLE
Redesign the 5X5 game layout for symmetry

### DIFF
--- a/cardtable.py
+++ b/cardtable.py
@@ -169,7 +169,7 @@ class CardTable(Gtk.EventBox):
                 card.connect('event', self.__event_cb, [x, y])
             else:
                 card = Gtk.EventBox()
-                card.modify_bg(Gtk.StateType.NORMAL, Gdk.color_parse('#000000'))
+                card.modify_bg(Gtk.StateType.NORMAL, Gdk.color_parse(self._background_color))
                 card.set_size_request(self.card_size, self.card_size)
 
             self.table_positions[(x, y)] = 1

--- a/cardtable.py
+++ b/cardtable.py
@@ -140,32 +140,37 @@ class CardTable(Gtk.EventBox):
             show_robot = True
 
         for card in self.cards_data:
-            if card.get('img', None):
-                image_path = os.path.join(self.data['pathimg'], card['img'])
+            if card:
+                if card.get('img', None):
+                    image_path = os.path.join(self.data['pathimg'], card['img'])
+                else:
+                    image_path = None
+                props = {}
+                props['front_text'] = {'card_text': card.get('char', ''),
+                                    'speak': card.get('speak')}
+
+                if card['ab'] == 'a':
+                    props['back_text'] = {'card_text': text1}
+                    font_name = font_name1
+                    props['back'] = {'fill_color': background_color1,
+                                    'stroke_color': background_color1}
+                elif card['ab'] == 'b':
+                    props['back_text'] = {'card_text': text2}
+                    font_name = font_name2
+                    props['back'] = {'fill_color': background_color2,
+                                    'stroke_color': background_color2}
+
+                card = Card(
+                    identifier, props, image_path,
+                    self.card_size, self._background_color, font_name, show_robot)
+                card.connect('enter-notify-event', self.mouse_event, [x, y])
+                card.set_events(Gdk.EventMask.TOUCH_MASK |
+                                Gdk.EventMask.BUTTON_PRESS_MASK)
+                card.connect('event', self.__event_cb, [x, y])
             else:
-                image_path = None
-            props = {}
-            props['front_text'] = {'card_text': card.get('char', ''),
-                                   'speak': card.get('speak')}
-
-            if card['ab'] == 'a':
-                props['back_text'] = {'card_text': text1}
-                font_name = font_name1
-                props['back'] = {'fill_color': background_color1,
-                                 'stroke_color': background_color1}
-            elif card['ab'] == 'b':
-                props['back_text'] = {'card_text': text2}
-                font_name = font_name2
-                props['back'] = {'fill_color': background_color2,
-                                 'stroke_color': background_color2}
-
-            card = Card(
-                identifier, props, image_path,
-                self.card_size, self._background_color, font_name, show_robot)
-            card.connect('enter-notify-event', self.mouse_event, [x, y])
-            card.set_events(Gdk.EventMask.TOUCH_MASK |
-                            Gdk.EventMask.BUTTON_PRESS_MASK)
-            card.connect('event', self.__event_cb, [x, y])
+                card = Gtk.EventBox()
+                card.modify_bg(Gtk.StateType.NORMAL, Gdk.color_parse('#000000'))
+                card.set_size_request(self.card_size, self.card_size)
 
             self.table_positions[(x, y)] = 1
             self.cd2id[card] = identifier
@@ -220,25 +225,29 @@ class CardTable(Gtk.EventBox):
             if (x - 1, y) in self.table_positions:
                 card = self.cards[x - 1, y]
                 identifier = self.cd2id.get(card)
-                self.emit('card-highlighted', identifier, False)
+                if not (self.size == 5 and identifier == 12):
+                    self.emit('card-highlighted', identifier, False)
 
         elif event.keyval in (Gdk.KEY_Right, Gdk.KEY_KP_Right):
             if (x + 1, y) in self.table_positions:
                 card = self.cards[x + 1, y]
                 identifier = self.cd2id.get(card)
-                self.emit('card-highlighted', identifier, False)
+                if not (self.size == 5 and identifier == 12):
+                    self.emit('card-highlighted', identifier, False)
 
         elif event.keyval in (Gdk.KEY_Up, Gdk.KEY_KP_Up):
             if (x, y - 1) in self.table_positions:
                 card = self.cards[x, y - 1]
                 identifier = self.cd2id.get(card)
-                self.emit('card-highlighted', identifier, False)
+                if not (self.size == 5 and identifier == 12):
+                    self.emit('card-highlighted', identifier, False)
 
         elif event.keyval in (Gdk.KEY_Down, Gdk.KEY_KP_Down):
             if (x, y + 1) in self.table_positions:
                 card = self.cards[x, y + 1]
                 identifier = self.cd2id.get(card)
-                self.emit('card-highlighted', identifier, False)
+                if not (self.size == 5 and identifier == 12):
+                    self.emit('card-highlighted', identifier, False)
 
         elif event.keyval in (Gdk.KEY_space, Gdk.KEY_KP_Page_Down):
             card = self.cards[x, y]

--- a/game.py
+++ b/game.py
@@ -119,14 +119,17 @@ class MemorizeGame(GObject.GObject):
         self.model.data['running'] = 'False'
 
         for card in self.model.grid:
-            if card['state'] == '1':
-                self.emit('flip-card', self.model.grid.index(card), False)
-                self.last_flipped = self.model.grid.index(card)
-            elif card['state'] != '0':
-                stroke_color, fill_color = card['state'].split(',')
-                self.emit('flip-card', self.model.grid.index(card), False)
-                self.emit('set-border', self.model.grid.index(card),
-                          stroke_color, fill_color)
+            try:
+                if card['state'] == '1':
+                    self.emit('flip-card', self.model.grid.index(card), False)
+                    self.last_flipped = self.model.grid.index(card)
+                elif card['state'] != '0':
+                    stroke_color, fill_color = card['state'].split(',')
+                    self.emit('flip-card', self.model.grid.index(card), False)
+                    self.emit('set-border', self.model.grid.index(card),
+                              stroke_color, fill_color)
+            except KeyError:
+                continue
         logging.debug('load_remote set is_demo mode %s', mode)
         if mode != 'reset':
             self.model.is_demo = (mode == 'demo')

--- a/game.py
+++ b/game.py
@@ -119,7 +119,7 @@ class MemorizeGame(GObject.GObject):
         self.model.data['running'] = 'False'
 
         for card in self.model.grid:
-            try:
+            if len(card) > 0:
                 if card['state'] == '1':
                     self.emit('flip-card', self.model.grid.index(card), False)
                     self.last_flipped = self.model.grid.index(card)
@@ -128,7 +128,7 @@ class MemorizeGame(GObject.GObject):
                     self.emit('flip-card', self.model.grid.index(card), False)
                     self.emit('set-border', self.model.grid.index(card),
                               stroke_color, fill_color)
-            except KeyError:
+            else:
                 continue
         logging.debug('load_remote set is_demo mode %s', mode)
         if mode != 'reset':

--- a/model.py
+++ b/model.py
@@ -419,10 +419,14 @@ class Model(object):
         if self.data['divided'] == '1':
             random.shuffle(temp1)
             random.shuffle(temp2)
+            if size == 5:
+                temp1.append({})
             temp1.extend(temp2)
         else:
             temp1.extend(temp2)
             random.shuffle(temp1)
+            if size == 5:
+                temp1.insert(12, {})
         self.grid = temp1
         logging.debug('Defgrid: grid( size=%s ): %s'
                       % (self.data['size'], self.grid))


### PR DESCRIPTION
Implements #17 

**Changes**
1) `cardtable.py`
2) `model.py`
3) `game.py`

**Updates**
For the 5X5 tile page, I have added an inactive black tile
at the center of layout. The black tile is unresponsive to any event/signal
and thus completely inactive.
This ensures that the layout is symmetrical.

**Testing**
1) I haven't yet tested the above feature on collaboration. I shall do that soon. I invite others to test the changes as well.

Thanks!

Tested on Ubuntu 18.04 and Sugar v0.114 