### PR TITLE
Fix TypeError due to Bool arguments in ElementTree

### DIFF
--- a/model.py
+++ b/model.py
@@ -335,22 +335,13 @@ class Model(object):
 
         for key in self.pairs:
             pair_props = {}
-            if self.pairs[key].props.aimg is not None:
-                pair_props["aimg"] = self.pairs[key].props.aimg
-            if self.pairs[key].props.asnd is not None:
-                pair_props["asnd"] = self.pairs[key].props.asnd
-            if self.pairs[key].props.achar is not None:
-                pair_props["achar"] = self.pairs[key].props.achar
-            if self.pairs[key].props.bimg is not None:
-                pair_props["bimg"] = self.pairs[key].props.bimg
-            if self.pairs[key].props.bsnd is not None:
-                pair_props["bsnd"] = self.pairs[key].props.bsnd
-            if self.pairs[key].props.bchar is not None:
-                pair_props["bchar"] = self.pairs[key].props.bchar
-            if self.pairs[key].props.aspeak is not None:
-                pair_props["aspeak"] = self.pairs[key].props.aspeak
-            if self.pairs[key].props.bspeak is not None:
-                pair_props["bspeak"] = self.pairs[key].props.bspeak
+            for e in ["aimg", "asnd", "achar", "bimg", "bsnd",
+                      "bchar", "aspeak", "bspeak"]:
+                if self.pairs[key].get_property(e) is not None:
+                    if self.pairs[key].get_property(e) is False:
+                        pair_props[e] = ""
+                    else:
+                        pair_props[e] = self.pairs[key].get_property(e)
             SubElement(root, 'pair', pair_props)
 
         with open(join(self.game_path, 'game.xml'), 'wb') as xml_file:


### PR DESCRIPTION
Caused due to presence of Boolean arguments (False) while writing to
`game.xml`.

If `speak` is not set, it defaults to `False` in set_speak()
in `card.py`. The fix changes `False` to an empty String while writing
to `game.xml`.

Traceback:
```
1594050507.412289 ERROR root: Error saving activity object to datastore
Traceback (most recent call last):
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 1076, in _escape_attrib
    if "&" in text:
TypeError: argument of type 'bool' is not iterable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/sugar3/activity/activity.py", line 1277, in _prepare_close
    self.save()
  File "/usr/lib/python3/dist-packages/sugar3/activity/activity.py", line 978, in save
    self.write_file(file_path)
  File "/usr/share/sugar/activities/Memorize.activity/activity.py", line 409, in write_file
    self.game.model.write()
  File "/usr/share/sugar/activities/Memorize.activity/model.py", line 357, in write
    xml_file.write(tostring(root))
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 1133, in tostring
    ElementTree(element).write(stream, encoding,
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 772, in write
    serialize(write, self._root, qnames, namespaces,
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 937, in _serialize_xml
    _serialize_xml(write, e, qnames, None,
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 930, in _serialize_xml
    v = _escape_attrib(v)
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 1099, in _escape_attrib
    _raise_serialization_error(text)
  File "/usr/lib/python3.8/xml/etree/ElementTree.py", line 1053, in _raise_serialization_error
    raise TypeError(
TypeError: cannot serialize False (type bool)
```

Fixes #29